### PR TITLE
mips: Change stack location to solve aliasing

### DIFF
--- a/cpu/ralink_soc/start.S
+++ b/cpu/ralink_soc/start.S
@@ -2397,7 +2397,9 @@ tRFCinit:
 	nop
 	bal		fill_icache
 	nop
-	li		sp, 0x89000000+0x1F00
+	li	t0, CFG_SDRAM_BASE + CFG_INIT_SP_OFFSET
+	la	sp, 0(t0)
+
 #endif	
 #endif	
 	la	t9, board_init_f


### PR DESCRIPTION
Previously, when U-Boot was configured to run from ROM the stack was configured
to be at 0x89001F00 after U-Boot's relocation. For devices with less than 256MB
RAM, the stack is located at an alias of memory. i.e. 0x89001F00 aliases to
0x81001F00 on a MT7628 board with 128MB DRAM. As U-Boot is running from cached
memory, the cache becomes filled with data for the aliased addresses.

When the kernel starts, it writes back the contents of the cache. The D$
aliases to the same physical memory result in unpredictable content in memory
after the cache writeback.

This manifested as DT corruption early in the kernel boot, causing a kernel
panic.

[    0.000000] Unhandled kernel unaligned access[#1]:
[    0.000000] CPU: 0 PID: 0 Comm: swapper Not tainted 4.12.0+ #19
[    0.000000] task: 8025d750 task.stack: 8025a000
[    0.000000] $ 0   : 00000000 00000000 02118821 80264a80
[    0.000000] $ 4   : 80250000 00000000 0000094a 00000000
[    0.000000] $ 8   : 296c6c75 66203a79 5f6c6c75 656d616e
[    0.000000] $12   : 801fc960 0000000f 03bd0000 bc000000
[    0.000000] $16   : 81001e10 80210000 8029b354 80256b88
[    0.000000] $20   : 00000000 80256cf0 8029b394 80250000
[    0.000000] $24   : 00000000 00000010
[    0.000000] $28   : 8025a000 8025bd98 802c0000 801d8648
[    0.000000] Hi    : 00000000
[    0.000000] Lo    : 00000000
[    0.000000] epc   : 801d8658 __of_find_property+0x58/0x19c
[    0.000000] ra    : 801d8648 __of_find_property+0x48/0x19c
[    0.000000] Status: 11000002	KERNEL EXL
[    0.000000] Cause : 40808010 (ExcCode 04)
[    0.000000] BadVA : 0211882d
[    0.000000] PrId  : 00019655 (MIPS 24KEc)
[    0.000000] Process swapper (pid: 0, threadinfo=8025a000, task=8025d750, tls=00000000)
[    0.000000] *HwTLS: 7739c440
[    0.000000] Stack : 00000000 80209e70 00000400 8029b354 00000000 00000000 8029b354 81001e10
[    0.000000]         8029b374 80256cf0 8029b394 801db06c 810013b0 80256cf0 8029b354 80250000
[    0.000000]         8029b354 00000000 00000000 81001e10 810013b0 80256cf0 8029b354 801db3a8
[    0.000000]         80209e3c 8009da70 00000001 81001e10 00000058 81001e10 00000000 8025be80
[    0.000000]         80209e3c 801db520 00000000 80209e3c 00000400 00000000 80257ee4 87c0b0e0
[    0.000000]         ...
[    0.000000] Call Trace:
[    0.000000] [<801d8658>] __of_find_property+0x58/0x19c
[    0.000000] [<801db06c>] __of_device_is_compatible+0x58/0x148
[    0.000000] [<801db3a8>] __of_match_node+0x4c/0x98
[    0.000000] [<801db520>] of_find_matching_node_and_match+0xac/0x144
[    0.000000] [<80296d3c>] of_irq_init+0x12c/0x3bc
[    0.000000] [<802837e4>] init_IRQ+0x3c/0x9c
[    0.000000] [<80281aec>] start_kernel+0x2a4/0x420
[    0.000000] Code: 10400005  00000000  3c048025 <8c45000c> 0c027694  2484693c  12000043  00001025  3c168025
[    0.000000]
[    0.000000] ---[ end trace 0000000000000000 ]---

Fix this by moving the stack to a non-aliased address.

Signed-off-by: Harvey Hunt <harvey.hunt@imgtec.com>

[Note: I haven't tested this using a linkit, but it should be fine...]