### PR TITLE
fixes missing ra_inl and ra_outl for mt7620

### DIFF
--- a/board/rt2880/serial.c
+++ b/board/rt2880/serial.c
@@ -36,6 +36,15 @@
 #define cpu_to_le32(x) (x)
 #endif
 
+#ifndef ra_inl
+#define ra_inl(addr)  (*(volatile unsigned int *)(addr))
+#endif
+
+#ifndef ra_outl
+#define ra_outl(addr, value)  (*(volatile unsigned int *)(addr) = (value))
+#endif
+
+
 #if defined(RT6855A_ASIC_BOARD) || defined(RT6855A_FPGA_BOARD)
 static unsigned long uclk_20M[13]={ // 65000*(b*16*1)/2000000
 	59904,          // Baud rate 115200


### PR DESCRIPTION
Dear Mediatek labs,

When build u-boot for MT7620A boards, ra_inl and ra_outl is missing in serial.c.
I would like submit a fix for this.


